### PR TITLE
Fix deprecated landsat collection

### DIFF
--- a/LandTrendr.js
+++ b/LandTrendr.js
@@ -52,7 +52,7 @@ exports.harmonizationRoy = harmonizationRoy;
 
 //------ FILTER A COLLECTION FUNCTION -----
 var filterCollection = function(year, startDay, endDay, sensor, aoi){
-  return ee.ImageCollection('LANDSAT/'+ sensor + '/C01/T1_SR')
+  return ee.ImageCollection('LANDSAT/'+ sensor + '/C02/T1_L2')
            .filterBounds(aoi)
            .filterDate(year+'-'+startDay, year+'-'+endDay);
 };


### PR DESCRIPTION
Hey, I was just working with the LT-GEE API and I noticed the Landsat collection being used is deprecated. 
I don't have a deep understanding of all the inner workings of the API - so please let me know if it isn't possible or a good idea to switch to the new collection. 

The API gives a warning, pointing here:
- https://developers.google.com/earth-engine/guides/landsat#landsat-collection-structure

and other mentions of this collection being deprecated:
- https://developers.google.com/earth-engine/datasets/catalog/landsat
- https://www.usgs.gov/landsat-missions/landsat-collection-1

and from the user group [here](https://groups.google.com/g/google-earth-engine-developers/c/YuIxsojV7ao/m/4_0l8cNAAwAJ) (Jan 3 2022):
![image](https://user-images.githubusercontent.com/16324625/153684794-d22fa4e0-e081-4fa3-bf3a-065fbac48497.png)

As far as I can tell, L7, L8 Collection 2 have been fully ingested in Earth Engine. Not sure about L5. 

Here's a script I used to quickly compare the two collections:
https://code.earthengine.google.com/31b105327aa3e1a9f0dce85f9bad7bb6

From my understanding of the LT-GEE API, we'd need to apply the scaling factors given in the example script "Examples/Datasets/LANDSAT_LC08_C02_T1_L2"
https://code.earthengine.google.com/638c03d87892e6ab853cd855fab44923

I'm not sure how this interacts with the Roy et al. harmonization though. So it's definitely not a one single line of code change, but I thought I'd open this to put it out there. 

Thank you!